### PR TITLE
New SQL Query objects for EF

### DIFF
--- a/Highway/src/Highway.Data.EntityFramework/Highway.Data.EntityFramework.csproj
+++ b/Highway/src/Highway.Data.EntityFramework/Highway.Data.EntityFramework.csproj
@@ -103,9 +103,12 @@
     <Compile Include="Mappings\TypeMappings.cs" />
     <Compile Include="PrebuiltInterceptors\AppendWhere.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="QueryObjects\SqlCommand.cs" />
+    <Compile Include="QueryObjects\SqlQuery.cs" />
     <Compile Include="QueryObjects\AdvancedCommand.cs" />
     <Compile Include="QueryObjects\AdvancedQuery.cs" />
     <Compile Include="QueryObjects\AdvancedScalar.cs" />
+    <Compile Include="QueryObjects\SqlScalar.cs" />
     <Compile Include="Repositories\DomainRepository.cs" />
     <Compile Include="StoredProcedures\StoredProcedureAttributes.cs" />
     <Compile Include="StoredProcedures\StoredProcedureHelpers.cs" />

--- a/Highway/src/Highway.Data.EntityFramework/QueryObjects/SqlCommand.cs
+++ b/Highway/src/Highway.Data.EntityFramework/QueryObjects/SqlCommand.cs
@@ -1,0 +1,24 @@
+using System;
+using System.Collections.Generic;
+using System.Data.Common;
+using System.Data.Entity;
+using System.Data.SqlClient;
+using System.Linq;
+using System.Linq.Expressions;
+
+namespace Highway.Data
+{
+    public abstract class SqlCommand : ICommand
+    {
+        protected Action<SqlConnection> ContextQuery;
+
+        public void Execute(IDataContext context)
+        {
+            var efContext = context as DbContext;
+            using (var conn = new SqlConnection(efContext.Database.Connection.ConnectionString))
+            {
+                ContextQuery.Invoke(conn);
+            }
+        }
+    }
+}

--- a/Highway/src/Highway.Data.EntityFramework/QueryObjects/SqlQuery.cs
+++ b/Highway/src/Highway.Data.EntityFramework/QueryObjects/SqlQuery.cs
@@ -1,0 +1,36 @@
+using System;
+using System.Collections.Generic;
+using System.Data.Common;
+using System.Data.Entity;
+using System.Data.SqlClient;
+using System.Linq;
+using System.Linq.Expressions;
+
+namespace Highway.Data
+{
+    public class SqlQuery<T> : IQuery<T>
+    {
+        protected Func<DbConnection, IEnumerable<T>> ContextQuery;
+
+        public string SqlStatement { get; set; }
+
+        public IEnumerable<T> Execute(IDataContext context)
+        {
+            var efContext = context as DbContext;
+            using (var conn = new SqlConnection(efContext.Database.Connection.ConnectionString))
+            {
+                return ContextQuery.Invoke(conn);
+            }
+        }
+
+        public string OutputQuery(IDataContext context)
+        {
+            return SqlStatement;
+        }
+
+        public string OutputSQLStatement(IDataContext context)
+        {
+            return OutputQuery(context);
+        }
+    }
+}

--- a/Highway/src/Highway.Data.EntityFramework/QueryObjects/SqlScalar.cs
+++ b/Highway/src/Highway.Data.EntityFramework/QueryObjects/SqlScalar.cs
@@ -1,0 +1,24 @@
+using System;
+using System.Collections.Generic;
+using System.Data.Common;
+using System.Data.Entity;
+using System.Data.SqlClient;
+using System.Linq;
+using System.Linq.Expressions;
+
+namespace Highway.Data
+{
+    public abstract class SqlScalar<T> : IScalar<T>
+    {
+        protected Func<SqlConnection, T> ContextQuery;
+
+        public T Execute(IDataContext context)
+        {
+            var efContext = context as DbContext;
+            using (var conn = new SqlConnection(efContext.Database.Connection.ConnectionString))
+            {
+                return ContextQuery.Invoke(conn);
+            }
+        }
+    }
+}


### PR DESCRIPTION
This introduces a MicroORM friendly set of Command/Query/Scalar objects intro Highway.EntityFramework.  We are not re-using any of the EntityFramework connection objects, so we don't run the risk of offending EF's connection management, while still allowing advanced scenarios to fall all the way back to a MicroORM on top of Ado if needed.
