### PR TITLE
Fixed collection type reflection issues

### DIFF
--- a/Highway/src/Highway.Data/Contexts/TypeRepresentations/ObjectRepresentationRepository.cs
+++ b/Highway/src/Highway.Data/Contexts/TypeRepresentations/ObjectRepresentationRepository.cs
@@ -120,7 +120,9 @@ namespace Highway.Data.Contexts.TypeRepresentations
         {
             List<ObjectRepresentation> reps = new List<ObjectRepresentation>();
             var properties =
-                item.GetType().GetProperties(BindingFlags.Public | BindingFlags.Instance).Where(x => x.PropertyType.IsClass);
+                item.GetType()
+                    .GetProperties(BindingFlags.Public | BindingFlags.Instance)
+                    .Where(x => x.PropertyType.IsClass && !typeof(IEnumerable).IsAssignableFrom(x.PropertyType));
             foreach (var propertyInfo in properties)
             {
                 var child = propertyInfo.GetValue(item, null);


### PR DESCRIPTION
When you add a new type to the InMemoryDataContext it will try to create a repository through reflection. It will fail with relationships that are collections when attempting to find all the singular relationships. The fixing code was pulled from v5.0.6.0
