### PR TITLE
Allow iterating and adding to InMemoryDataContext.

### DIFF
--- a/Highway/test/Highway.Data.Tests/Highway.Data.Tests.csproj
+++ b/Highway/test/Highway.Data.Tests/Highway.Data.Tests.csproj
@@ -118,6 +118,7 @@
     <Compile Include="InMemory\GuidIdentityStrategyTests.cs" />
     <Compile Include="InMemory\InMemoryDataContextPerfTests.cs" />
     <Compile Include="InMemory\InMemoryDataContextAutoRegisterIdentityStrategiesTests.cs" />
+    <Compile Include="InMemory\InMemoryDataContextReferenceByIdTests.cs" />
     <Compile Include="InMemory\IntegerIdentityStrategyTests.cs" />
     <Compile Include="InMemory\Domain\Author.cs" />
     <Compile Include="InMemory\Domain\Blog.cs" />

--- a/Highway/test/Highway.Data.Tests/InMemory/InMemoryDataContextReferenceByIdTests.cs
+++ b/Highway/test/Highway.Data.Tests/InMemory/InMemoryDataContextReferenceByIdTests.cs
@@ -1,0 +1,61 @@
+﻿#region
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using FluentAssertions;
+using Highway.Data.Contexts;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+#endregion
+
+namespace Highway.Data.Tests.InMemory
+{
+    [TestClass]
+    public class InMemoryDataContextReferenceByIdTests
+    {
+        private InMemoryDataContext _context;
+
+        [TestInitialize]
+        public void Setup()
+        {
+            _context = new InMemoryDataContext();
+        }
+
+        [TestMethod]
+        public void ShouldBeAbleToIterate()
+        {
+            _context.Add(new Blog());
+            _context.Add(new Blog());
+            _context.Commit();
+
+            try
+            {
+                foreach (var blogId in _context.AsQueryable<Blog>().Select(b => b.Id))
+                {
+                    var post = new Post { BlogId = blogId };
+                    _context.Add(post);
+                }
+            }
+            catch (Exception e)
+            {
+                Assert.Fail(e.Message);
+            }
+        }
+
+        class Blog : IIdentifiable<long>
+        {
+            public Blog()
+            {
+                Posts = new List<Post>();
+            }
+            public long Id { get; set; }
+            public List<Post> Posts { get; set; }
+        }
+        class Post : IIdentifiable<long>
+        {
+            public long Id { get; set; }
+            public long BlogId { get; set; }
+        }
+    }
+}


### PR DESCRIPTION
InMemoryDataContext queues add and remove, not altering collection.
Breaks tests if tests are ignoring to call commit after add or remove for convenience.

Close https://github.com/HighwayFramework/Highway.Data/issues/63 after pull.
