### PR TITLE
Handling null collections

### DIFF
--- a/Highway/SolutionInfo.cs
+++ b/Highway/SolutionInfo.cs
@@ -30,8 +30,8 @@ using System.Runtime.InteropServices;
 //
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
-// [assembly: AssemblyVersion("6.0.1.0")]
+// [assembly: AssemblyVersion("6.0.1.5")]
 
-[assembly: AssemblyVersion("6.0.1.0")]
-[assembly: AssemblyFileVersion("6.0.1.0")]
-[assembly: AssemblyInformationalVersion("6.0.1.0")]
+[assembly: AssemblyVersion("6.0.1.5")]
+[assembly: AssemblyFileVersion("6.0.1.5")]
+[assembly: AssemblyInformationalVersion("6.0.1.5")]

--- a/Highway/src/Highway.Data.EntityFramework/Highway.Data.EntityFramework.nuspec
+++ b/Highway/src/Highway.Data.EntityFramework/Highway.Data.EntityFramework.nuspec
@@ -14,7 +14,7 @@
     <copyright>Devlin Liles Copyright 2012</copyright>
     <tags>Architecture  ORM  Repository  Specification  Productivity</tags>
     <dependencies>
-      <dependency id="Highway.Data" version="6.0.1.0" />
+      <dependency id="Highway.Data" version="6.0.1.5" />
 	  <dependency id="EntityFramework" version="6.1.3" />
     </dependencies>
   </metadata>

--- a/Highway/src/Highway.Data/Contexts/TypeRepresentations/ObjectRepresentationRepository.cs
+++ b/Highway/src/Highway.Data/Contexts/TypeRepresentations/ObjectRepresentationRepository.cs
@@ -94,10 +94,7 @@ namespace Highway.Data.Contexts.TypeRepresentations
                         collection = Activator.CreateInstance(collectionType);
                         referencingProperty.SetValue(data.Entity, collection, null);
                     }
-                    //if (collection != null)
-                    {
-                        addMethod.Invoke(collection, new[] { rep.Entity });
-                    }
+                    addMethod.Invoke(collection, new[] { rep.Entity });
                 }
                 else
                 {

--- a/Highway/src/Highway.Data/Contexts/TypeRepresentations/ObjectRepresentationRepository.cs
+++ b/Highway/src/Highway.Data/Contexts/TypeRepresentations/ObjectRepresentationRepository.cs
@@ -2,6 +2,7 @@
 using System;
 using System.Collections;
 using System.Collections.Generic;
+using System.Collections.ObjectModel;
 using System.IO;
 using System.Linq;
 using System.Reflection;
@@ -54,7 +55,10 @@ namespace Highway.Data.Contexts.TypeRepresentations
                     if (info.PropertyType.IsEnumerable())
                     {
                         IEnumerable values = (IEnumerable) info.GetValue(rep.Entity, null);
-                        referencedProperties.AddRange(values.Cast<object>());
+                        if (values != null)
+                        {
+                            referencedProperties.AddRange(values.Cast<object>());
+                        }
                     }
                     else
                     {
@@ -84,7 +88,16 @@ namespace Highway.Data.Contexts.TypeRepresentations
                 if (referencingProperty.PropertyType.IsAssignableFrom(collectionType))
                 {
                     var collection = referencingProperty.GetValue(data.Entity, null);
-                    addMethod.Invoke(collection, new[] { rep.Entity });
+                    if (collection == null)
+                    {
+                        collectionType = typeof(Collection<>).MakeGenericType(type);
+                        collection = Activator.CreateInstance(collectionType);
+                        referencingProperty.SetValue(data.Entity, collection, null);
+                    }
+                    //if (collection != null)
+                    {
+                        addMethod.Invoke(collection, new[] { rep.Entity });
+                    }
                 }
                 else
                 {

--- a/Highway/src/Highway.Data/Contexts/TypeRepresentations/ObjectRepresentationRepository.cs
+++ b/Highway/src/Highway.Data/Contexts/TypeRepresentations/ObjectRepresentationRepository.cs
@@ -77,7 +77,7 @@ namespace Highway.Data.Contexts.TypeRepresentations
                 var propertiesThatReferToRepresentation =
                     data.Entity.GetType()
                         .GetProperties()
-                        .Where(x => x.PropertyType == type || x.PropertyType.IsAssignableFrom(collectionType));
+                        .Where(x => x.CanWrite && (x.PropertyType == type || x.PropertyType.IsAssignableFrom(collectionType)));
                 var addMethod = collectionType.GetMethod("Add");
                 var propertyInfos = propertiesThatReferToRepresentation.ToList();
                 if (!propertyInfos.Any() || propertyInfos.Count() > 1)

--- a/Highway/src/Highway.Data/Repositories/Repository.cs
+++ b/Highway/src/Highway.Data/Repositories/Repository.cs
@@ -35,7 +35,7 @@ namespace Highway.Data
         /// <param name="command">The prebuilt command object</param>
         public virtual void Execute(ICommand command)
         {
-            ExecuteAsync(command).Wait();
+            command.Execute(_context);
         }
 
         /// <summary>
@@ -46,7 +46,7 @@ namespace Highway.Data
         /// <returns>The instance of <typeparamref name="T" /> returned from the query</returns>
         public virtual T Find<T>(IScalar<T> query)
         {
-            return FindAsync(query).Result;
+            return query.Execute(_context);
         }
 
         /// <summary>
@@ -57,7 +57,7 @@ namespace Highway.Data
         /// <returns>The <see cref="IEnumerable{T}" /> returned from the query</returns>
         public virtual IEnumerable<T> Find<T>(IQuery<T> query)
         {
-            return FindAsync(query).Result;
+            return query.Execute(_context);
         }
 
         /// <summary>
@@ -69,7 +69,7 @@ namespace Highway.Data
         public virtual IEnumerable<IProjection> Find<TSelection, IProjection>(IQuery<TSelection, IProjection> query)
             where TSelection : class
         {
-            return FindAsync(query).Result;
+            return query.Execute(_context);
         }
 
         /// <summary>

--- a/Highway/test/Highway.Data.Tests/InMemory/Bug Tests/PopulateReferencesTests.cs
+++ b/Highway/test/Highway.Data.Tests/InMemory/Bug Tests/PopulateReferencesTests.cs
@@ -26,6 +26,7 @@ namespace Highway.Data.Tests.InMemory.BugTests
 
             // Assert
             fetchedBlog.Posts.Count().Should().Be(1);
+            fetchedBlog.InvalidPosts.Should().BeNullOrEmpty();
         }
 
         [TestMethod]
@@ -48,6 +49,7 @@ namespace Highway.Data.Tests.InMemory.BugTests
 
             // Assert
             fetchedPost.Blog.Should().NotBeNull();
+            fetchedPost.Blog.InvalidPosts.Should().BeNullOrEmpty();
         }
     }
 }

--- a/Highway/test/Highway.Data.Tests/InMemory/Bug Tests/PopulateReferencesTests.cs
+++ b/Highway/test/Highway.Data.Tests/InMemory/Bug Tests/PopulateReferencesTests.cs
@@ -16,7 +16,8 @@ namespace Highway.Data.Tests.InMemory.BugTests
             // Arrange
             var context = new InMemoryDataContext();
             var blog = new Blog();
-            var post = new Post { Blog = blog };
+            blog.AddPost(new Post());
+            var post = blog.Posts.First();
             context.Add(post);
             context.Commit();
 

--- a/Highway/test/Highway.Data.Tests/InMemory/Domain/Blog.cs
+++ b/Highway/test/Highway.Data.Tests/InMemory/Domain/Blog.cs
@@ -26,5 +26,13 @@ namespace Highway.Data.Tests.InMemory.Domain
         public Author Author { get; set; }
 
         public ICollection<Post> Posts { get; set; }
+
+        public ICollection<Post> InvalidPosts { get; set; }
+
+        public void AddPost(Post post)
+        {
+            Posts.Add(post);
+            post.Blog = this;
+        }
     }
 }

--- a/default.ps1
+++ b/default.ps1
@@ -11,7 +11,7 @@ properties {
     $build_config = "Release"
     $pack_dir = ".\pack"
     $build_archive = ".\buildarchive\"
-    $version_number = "6.0.1.0"
+    $version_number = "6.0.1.5"
     $nuget_version_number = $version_number
     if ($Env:BUILD_NUMBER -ne $null) {
         $nuget_version_number += "-$Env:BUILD_NUMBER"


### PR DESCRIPTION
Here are modifications to support the following:
* The InMemoryDataContext can now handle entities whose ICollection properties are null.
* The context will only write to properties that have a setter.
* Repository.Find was reverted to synchronously execute queries. The delegation to the async version caused time out exceptions.

