### PR TITLE
Cast the entity, not the ObjectRepresentation

### DIFF
--- a/Highway/src/Highway.Data/Contexts/TypeRepresentations/ObjectRepresentationRepository.cs
+++ b/Highway/src/Highway.Data/Contexts/TypeRepresentations/ObjectRepresentationRepository.cs
@@ -24,7 +24,7 @@ namespace Highway.Data.Contexts.TypeRepresentations
 
         internal IQueryable<T> Data<T>()
         {
-            return _data.Where(x => x.IsType<T>()).Select(x => x.Entity).Cast<T>().AsQueryable();
+            return _data.Select(x => x.Entity).OfType<T>().AsQueryable();
         }
 
         internal void Add<T>(T item) where T : class


### PR DESCRIPTION
The code was incorrectly trying to cast the ObjectRepresentation object instead of the Entity itself to `T` and was therefore coming back with nothing for every query. A bunch of the Hwy.Data tests (and my own) were broke. This change both fixes, and simplifies the Linq a bit.