### PR TITLE
Fix ObjectRepresentation.IsType

### DIFF
--- a/Highway/src/Highway.Data/Contexts/TypeRepresentations/ObjectRepresentation.cs
+++ b/Highway/src/Highway.Data/Contexts/TypeRepresentations/ObjectRepresentation.cs
@@ -21,7 +21,7 @@ namespace Highway.Data.Contexts.TypeRepresentations
 
         public bool IsType<T1>()
         {
-            return Entity.GetType() is T1;
+            return Entity is T1;
         }
 
         internal IEnumerable<ObjectRepresentation> AllRelated()


### PR DESCRIPTION
Lots of the InMemoryContext tests fail in the last revision.  I believe the problem is the ObjectRepresentation.IsType() method. In the previous versions, it returns "Entity.GetType() is T1;  But GetType() returns a value of type System.Type, and that will NEVER be a T1 (unless, of course, T1 happens to be System.Type).  So the InMemoryContext.AsQueryable<T> always returns an empty IQueryable.
Subsitututing "Entity is T1" makes all tests pass. 