### PR TITLE
Feature/in memory data context id counters

### DIFF
--- a/Highway/src/Highway.Data/Contexts/IdentityStrategy/GuidIdentityStrategy.cs
+++ b/Highway/src/Highway.Data/Contexts/IdentityStrategy/GuidIdentityStrategy.cs
@@ -1,26 +1,39 @@
-
 using System;
 using System.Linq.Expressions;
 
-
 namespace Highway.Data.Contexts
 {
+    /// <summary>
+    /// An implementation of <see cref="IdentityStrategy{TType,TIdentity}"/> for entities where the identity property has type Guid.
+    /// </summary>
+    /// <typeparam name="T">The type of the entities that will have identity values assigned.</typeparam>
     public class GuidIdentityStrategy<T> : IdentityStrategy<T, Guid>
         where T : class
     {
-        static GuidIdentityStrategy()
-        {
-            Generator = Guid.NewGuid;
-        }
-
+        /// <summary>
+        /// Creates an instance of <see cref="IdentityStrategy{TType,TIdentity}"/> for entities where the identity property has type Guid.  Uses the provided identity <paramref name="property"/> setter.
+        /// </summary>
+        /// <param name="property">The property setter used to set the identity value of an entity.</param>
         public GuidIdentityStrategy(Expression<Func<T, Guid>> property)
             : base(property)
         {
+            Generator = GenerateGuid;
         }
 
+        /// <summary>
+        /// Returns a value indicating whether a given value equals the default, unset identity value.
+        /// </summary>
+        /// <param name="id">The identity value to examine.</param>
+        /// <returns>A value indicating whether a given value equals the default, unset identity value.</returns>
         protected override bool IsDefaultUnsetValue(Guid id)
         {
             return id == Guid.Empty;
+        }
+
+        private Guid GenerateGuid()
+        {
+            SetLastValue(Guid.NewGuid());
+            return LastValue;
         }
     }
 }

--- a/Highway/src/Highway.Data/Contexts/IdentityStrategy/IIdentityStrategy.cs
+++ b/Highway/src/Highway.Data/Contexts/IdentityStrategy/IIdentityStrategy.cs
@@ -1,8 +1,16 @@
 namespace Highway.Data.Contexts
 {
-    public interface IIdentityStrategy<T>
+    /// <summary>
+    /// Provides an interface by which Identity values can be assigned.
+    /// </summary>
+    /// <typeparam name="T">The type of the </typeparam>
+    public interface IIdentityStrategy<in T>
         where T : class
     {
+        /// <summary>
+        /// Assigns an identity value to the given <paramref name="entity"/>.
+        /// </summary>
+        /// <param name="entity"></param>
         void Assign(T entity);
     }
 }

--- a/Highway/src/Highway.Data/Contexts/IdentityStrategy/IdentityStrategy.cs
+++ b/Highway/src/Highway.Data/Contexts/IdentityStrategy/IdentityStrategy.cs
@@ -1,69 +1,113 @@
-
 using System;
 using System.Linq.Expressions;
 using System.Reflection;
 
-
 namespace Highway.Data.Contexts
 {
+    /// <summary>
+    /// A base implementation of IIdentityStrategy.
+    /// </summary>
+    /// <typeparam name="TType">The type of the entities that will have identity values assigned.</typeparam>
+    /// <typeparam name="TIdentity">The type of the identity values to be assigned.</typeparam>
     public abstract class IdentityStrategy<TType, TIdentity> : IIdentityStrategy<TType>
         where TType : class
     {
-        public static TIdentity LastValue = default(TIdentity);
-        public static Func<TIdentity> Generator = null;
+        private readonly Action<TType> _identitySetter;
 
-        private readonly Action<TType> identitySetter;
+        private readonly object _lastValueLock = new object();
 
-        public IdentityStrategy(Expression<Func<TType, TIdentity>> property)
+        /// <summary>
+        /// Creates an instance of <see cref="IdentityStrategy{TType,TIdentity}"/> using the provided identity <paramref name="property"/> setter.
+        /// </summary>
+        /// <param name="property">The property setter used to set the identity value of an entity.</param>
+        protected IdentityStrategy(Expression<Func<TType, TIdentity>> property)
         {
-            identitySetter = obj => 
-            {
-                var propertyInfo = GetPropertyFromExpression(property);
-                var id = (TIdentity) propertyInfo.GetValue(obj, null);
-                if(IsDefaultUnsetValue(id)) propertyInfo.SetValue(obj,  Next(), null);
-            };
+            _identitySetter = obj =>
+                {
+                    var propertyInfo = GetPropertyFromExpression(property);
+                    var id = (TIdentity)propertyInfo.GetValue(obj, null);
+                    if (IsDefaultUnsetValue(id)) propertyInfo.SetValue(obj, Next(), null);
+                };
         }
 
-        protected abstract bool IsDefaultUnsetValue(TIdentity id);
+        /// <summary>
+        /// The last value used to set an identity value.
+        /// </summary>
+        public TIdentity LastValue { get; protected set; }
 
+        /// <summary>
+        /// The function used to generate identity values.
+        /// </summary>
+        public Func<TIdentity> Generator { get; protected set; } = null;
+
+        /// <summary>
+        /// Assigns an identity value to the given <paramref name="entity"/>.
+        /// </summary>
+        /// <param name="entity"></param>
         public void Assign(TType entity)
         {
-            identitySetter.Invoke(entity);
+            _identitySetter.Invoke(entity);
         }
 
+        /// <summary>
+        /// Invokes the generator to set the next appropriate value for the identity value.
+        /// </summary>
+        /// <returns>The next appropriate value for the identity value.</returns>
+        /// <exception cref="NotImplementedException"></exception>
         public TIdentity Next()
         {
-            if (Generator == null) throw new NotImplementedException();
-            return Generator.Invoke();
+            if (this.Generator == null) throw new NotImplementedException();
+            return this.Generator.Invoke();
         }
+
+        /// <summary>
+        /// A thread-safe method for setting the LastValue property
+        /// </summary>
+        /// <param name="value"></param>
+        protected void SetLastValue(TIdentity value)
+        {
+            lock (_lastValueLock)
+            {
+                LastValue = value;
+            }
+        }
+
+        /// <summary>
+        /// Returns a value indicating whether a given value equals the default, unset identity value.
+        /// </summary>
+        /// <param name="id">The identity value to examine.</param>
+        /// <returns>A value indicating whether a given value equals the default, unset identity value.</returns>
+        protected abstract bool IsDefaultUnsetValue(TIdentity id);
 
         private PropertyInfo GetPropertyFromExpression(Expression<Func<TType, TIdentity>> lambda)
         {
-            MemberExpression Exp = null;
-            Expression Sub;
+            MemberExpression memberExpression;
 
             // this line is necessary, because sometimes the expression 
             // comes as Convert(originalexpression)
-            if (lambda.Body is UnaryExpression)
+            var bodyExpression = lambda.Body as UnaryExpression;
+            if (bodyExpression != null)
             {
-                UnaryExpression UnExp = (UnaryExpression) lambda.Body;
-                if (UnExp.Operand is MemberExpression)
+                var operand = bodyExpression.Operand as MemberExpression;
+                if (operand != null)
                 {
-                    Exp = (MemberExpression) UnExp.Operand;
+                    memberExpression = operand;
                 }
                 else
+                {
                     throw new ArgumentException();
+                }
             }
             else if (lambda.Body is MemberExpression)
             {
-                Exp = (MemberExpression) lambda.Body;
+                memberExpression = (MemberExpression)lambda.Body;
             }
             else
             {
                 throw new ArgumentException();
             }
 
-            return (PropertyInfo) Exp.Member;
+            return (PropertyInfo)memberExpression.Member;
         }
     }
 }

--- a/Highway/src/Highway.Data/Contexts/IdentityStrategy/IntegerIdentityStrategy.cs
+++ b/Highway/src/Highway.Data/Contexts/IdentityStrategy/IntegerIdentityStrategy.cs
@@ -1,32 +1,39 @@
-﻿
-using System;
+﻿using System;
 using System.Linq.Expressions;
-using System.Threading;
-
 
 namespace Highway.Data.Contexts
 {
+    /// <summary>
+    /// An implementation of <see cref="IdentityStrategy{TType,TIdentity}"/> for entities where the identity property has type int
+    /// </summary>
+    /// <typeparam name="T">The type of the entities that will have identity values assigned.</typeparam>
     public class IntegerIdentityStrategy<T> : IdentityStrategy<T, int>
         where T : class
     {
-        static IntegerIdentityStrategy()
+        /// <summary>
+        /// Creates an instance of <see cref="IdentityStrategy{TType,TIdentity}"/> for entities where the identity property has type int.  Uses the provided identity <paramref name="property"/> setter.
+        /// </summary>
+        /// <param name="property">The property setter used to set the identity value of an entity.</param>
+        public IntegerIdentityStrategy(Expression<Func<T, int>> property)
+            : base(property)
         {
             Generator = GenerateInt;
         }
 
-        public IntegerIdentityStrategy(Expression<Func<T, int>> property)
-            : base(property)
-        {
-        }
-
-        private static int GenerateInt()
-        {
-            return Interlocked.Increment(ref LastValue);
-        }
-
+        /// <summary>
+        /// Returns a value indicating whether a given value equals the default, unset identity value.
+        /// </summary>
+        /// <param name="id">The identity value to examine.</param>
+        /// <returns>A value indicating whether a given value equals the default, unset identity value.</returns>
         protected override bool IsDefaultUnsetValue(int id)
         {
             return id == 0;
+        }
+
+        private int GenerateInt()
+        {
+            SetLastValue(++LastValue);
+            return LastValue;
         }
     }
 }

--- a/Highway/src/Highway.Data/Contexts/IdentityStrategy/LongIdentityStrategy.cs
+++ b/Highway/src/Highway.Data/Contexts/IdentityStrategy/LongIdentityStrategy.cs
@@ -1,31 +1,40 @@
-﻿
-using System;
+﻿using System;
 using System.Linq.Expressions;
-using System.Threading;
 
 
 namespace Highway.Data.Contexts
 {
+    /// <summary>
+    /// An implementation of <see cref="IdentityStrategy{TType,TIdentity}"/> for entities where the identity property has type long.
+    /// </summary>
+    /// <typeparam name="T">The type of the entities that will have identity values assigned.</typeparam>
     public class LongIdentityStrategy<T> : IdentityStrategy<T, long>
         where T : class
     {
-        static LongIdentityStrategy()
+        /// <summary>
+        /// Creates an instance of <see cref="IdentityStrategy{TType,TIdentity}"/> for entities where the identity property has type long.  Uses the provided identity <paramref name="property"/> setter.
+        /// </summary>
+        /// <param name="property">The property setter used to set the identity value of an entity.</param>
+        public LongIdentityStrategy(Expression<Func<T, long>> property)
+            : base(property)
         {
             Generator = GenerateLong;
         }
 
-        public LongIdentityStrategy(Expression<Func<T, long>> property)
-            : base(property)
-        {
-        }
-
-        private static long GenerateLong()
-        {
-            return Interlocked.Increment(ref LastValue);
-        }
+        /// <summary>
+        /// Returns a value indicating whether a given value equals the default, unset identity value.
+        /// </summary>
+        /// <param name="id">The identity value to examine.</param>
+        /// <returns>A value indicating whether a given value equals the default, unset identity value.</returns>
         protected override bool IsDefaultUnsetValue(long id)
         {
             return id == 0;
+        }
+
+        private long GenerateLong()
+        {
+            SetLastValue(++LastValue);
+            return LastValue;
         }
     }
 }

--- a/Highway/src/Highway.Data/Contexts/IdentityStrategy/ShortIdentityStrategy.cs
+++ b/Highway/src/Highway.Data/Contexts/IdentityStrategy/ShortIdentityStrategy.cs
@@ -1,33 +1,39 @@
-﻿
-using System;
+﻿using System;
 using System.Linq.Expressions;
-using System.Threading;
-
 
 namespace Highway.Data.Contexts
 {
+    /// <summary>
+    /// An implementation of <see cref="IdentityStrategy{TType,TIdentity}"/> for entities where the identity property has type short.
+    /// </summary>
+    /// <typeparam name="T">The type of the entities that will have identity values assigned.</typeparam>
     public class ShortIdentityStrategy<T> : IdentityStrategy<T, short>
         where T : class
     {
-        static Object lockObject = new Object();
-
-        static ShortIdentityStrategy()
+        /// <summary>
+        /// Creates an instance of <see cref="IdentityStrategy{TType,TIdentity}"/> for entities where the identity property has type short.  Uses the provided identity <paramref name="property"/> setter.
+        /// </summary>
+        /// <param name="property">The property setter used to set the identity value of an entity.</param>
+        public ShortIdentityStrategy(Expression<Func<T, short>> property)
+            : base(property)
         {
             Generator = GenerateShort;
         }
 
-        public ShortIdentityStrategy(Expression<Func<T, short>> property)
-            : base(property)
-        {
-        }
-
-        private static short GenerateShort()
-        {
-            lock (lockObject) { return ++LastValue; }
-        }
+        /// <summary>
+        /// Returns a value indicating whether a given value equals the default, unset identity value.
+        /// </summary>
+        /// <param name="id">The identity value to examine.</param>
+        /// <returns>A value indicating whether a given value equals the default, unset identity value.</returns>
         protected override bool IsDefaultUnsetValue(short id)
         {
             return id == 0;
+        }
+
+        private short GenerateShort()
+        {
+            SetLastValue(++LastValue);
+            return LastValue;
         }
     }
 }

--- a/Highway/src/Highway.Data/Highway.Data.csproj
+++ b/Highway/src/Highway.Data/Highway.Data.csproj
@@ -212,7 +212,6 @@
     <None Include="packages.config" />
   </ItemGroup>
   <ItemGroup>
-    <Folder Include="Contexts\IdentityStrategy\Configuration\" />
     <Folder Include="Contexts\TypeUtilities\" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />

--- a/Highway/src/Highway.Data/Highway.Data.csproj.DotSettings
+++ b/Highway/src/Highway.Data/Highway.Data.csproj.DotSettings
@@ -1,0 +1,2 @@
+﻿<wpf:ResourceDictionary xml:space="preserve" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:s="clr-namespace:System;assembly=mscorlib" xmlns:ss="urn:shemas-jetbrains-com:settings-storage-xaml" xmlns:wpf="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
+	<s:Boolean x:Key="/Default/CodeInspection/NamespaceProvider/NamespaceFoldersToSkip/=contexts_005Cidentitystrategy/@EntryIndexedValue">True</s:Boolean></wpf:ResourceDictionary>

--- a/Highway/test/Highway.Data.Tests/Entities/ExampleLeaf.cs
+++ b/Highway/test/Highway.Data.Tests/Entities/ExampleLeaf.cs
@@ -1,4 +1,4 @@
-﻿namespace Highway.Data.Tests.Security
+﻿namespace Highway.Data.Tests.Entities
 {
     public class ExampleLeaf : IIdentifiable<long>
     {

--- a/Highway/test/Highway.Data.Tests/Entities/ExampleRoot.cs
+++ b/Highway/test/Highway.Data.Tests/Entities/ExampleRoot.cs
@@ -1,4 +1,4 @@
-﻿namespace Highway.Data.Tests.Security
+﻿namespace Highway.Data.Tests.Entities
 {
     public class ExampleRoot : IIdentifiable<long>
     {

--- a/Highway/test/Highway.Data.Tests/InMemory/Domain/Site.cs
+++ b/Highway/test/Highway.Data.Tests/InMemory/Domain/Site.cs
@@ -1,8 +1,15 @@
-﻿namespace Highway.Data.Tests.InMemory.Domain
+﻿using System;
+
+namespace Highway.Data.Tests.InMemory.Domain
 {
     public class Site
     {
         public Blog Blog { get; set; }
         public int Id { get; set; }
+    }
+
+    public class IdentifiablePerson<T> : IIdentifiable<T> where T : IEquatable<T>
+    {
+        public T Id { get; set; }
     }
 }

--- a/Highway/test/Highway.Data.Tests/InMemory/InMemoryDataContextTests.cs
+++ b/Highway/test/Highway.Data.Tests/InMemory/InMemoryDataContextTests.cs
@@ -1,5 +1,4 @@
-﻿
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Linq;
 using FluentAssertions;
@@ -19,6 +18,60 @@ namespace Highway.Data.Tests.InMemory
         public void Setup()
         {
             _context = new InMemoryDataContext();
+        }
+
+        [TestMethod]
+        public void Add_ShouldCreateAFirstIdOfOneEveryTimeForANewInstanceOfIIdentifiableOfInt()
+        {
+            // Arrange
+            var longPerson = new IdentifiablePerson<int>();
+            _context.Add(longPerson);
+            _context.Commit();
+
+            // Act
+            var newLongPerson = new IdentifiablePerson<int>();
+            _context = new InMemoryDataContext();
+            _context.Add(newLongPerson);
+            _context.Commit();
+
+            // Assert
+            newLongPerson.Id.Should().Be(1);
+        }
+
+        [TestMethod]
+        public void Add_ShouldCreateAFirstIdOfOneEveryTimeForANewInstanceOfIIdentifiableOfLong()
+        {
+            // Arrange
+            var longPerson = new IdentifiablePerson<long>();
+            _context.Add(longPerson);
+            _context.Commit();
+
+            // Act
+            var newLongPerson = new IdentifiablePerson<long>();
+            _context = new InMemoryDataContext();
+            _context.Add(newLongPerson);
+            _context.Commit();
+
+            // Assert
+            newLongPerson.Id.Should().Be(1);
+        }
+
+        [TestMethod]
+        public void Add_ShouldCreateAFirstIdOfOneEveryTimeForANewInstanceOfIIdentifiableOfShort()
+        {
+            // Arrange
+            var longPerson = new IdentifiablePerson<short>();
+            _context.Add(longPerson);
+            _context.Commit();
+
+            // Act
+            var newLongPerson = new IdentifiablePerson<short>();
+            _context = new InMemoryDataContext();
+            _context.Add(newLongPerson);
+            _context.Commit();
+
+            // Assert
+            newLongPerson.Id.Should().Be(1);
         }
 
         [TestMethod]

--- a/Highway/test/Highway.Data.Tests/InMemory/IntegerIdentityStrategyTests.cs
+++ b/Highway/test/Highway.Data.Tests/InMemory/IntegerIdentityStrategyTests.cs
@@ -1,5 +1,4 @@
-﻿
-using FluentAssertions;
+﻿using FluentAssertions;
 using Highway.Data.Contexts;
 using Highway.Data.Tests.InMemory.Domain;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
@@ -10,13 +9,11 @@ namespace Highway.Data.Tests.InMemory
     [TestClass]
     public class IntegerIdentityStrategyTests
     {
-        private readonly int seedNumber = 500;
         private IntegerIdentityStrategy<Post> target;
 
         [TestInitialize]
         public void Setup()
         {
-            IntegerIdentityStrategy<Post>.LastValue = seedNumber;
             target = new IntegerIdentityStrategy<Post>(x => x.Id);
         }
 
@@ -29,7 +26,7 @@ namespace Highway.Data.Tests.InMemory
             int result = target.Next();
 
             // Assert
-            result.Should().Be(seedNumber + 1);
+            result.Should().Be(1);
         }
 
         [TestMethod]
@@ -42,7 +39,7 @@ namespace Highway.Data.Tests.InMemory
             target.Assign(post);
 
             // Assert
-            post.Id.Should().Be(seedNumber + 1);
+            post.Id.Should().Be(1);
         }
     }
 }

--- a/Highway/test/Highway.Data.Tests/InMemory/LongIdentityStrategyTests.cs
+++ b/Highway/test/Highway.Data.Tests/InMemory/LongIdentityStrategyTests.cs
@@ -1,7 +1,5 @@
-﻿
-using FluentAssertions;
+﻿using FluentAssertions;
 using Highway.Data.Contexts;
-using Highway.Data.Tests.InMemory.Domain;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 
@@ -10,13 +8,11 @@ namespace Highway.Data.Tests.InMemory
     [TestClass]
     public class LongIdentityStrategyTests
     {
-        private readonly long seedNumber = 500;
         private LongIdentityStrategy<Entity> target;
 
         [TestInitialize]
         public void Setup()
         {
-            LongIdentityStrategy<Entity>.LastValue = seedNumber;
             target = new LongIdentityStrategy<Entity>(x => x.Id);
         }
 
@@ -29,7 +25,7 @@ namespace Highway.Data.Tests.InMemory
             var result = target.Next();
 
             // Assert
-            result.Should().Be(seedNumber + 1);
+            result.Should().Be(1);
         }
 
         [TestMethod]
@@ -42,7 +38,7 @@ namespace Highway.Data.Tests.InMemory
             target.Assign(entity);
 
             // Assert
-            entity.Id.Should().Be(seedNumber + 1);
+            entity.Id.Should().Be(1);
         }
 
         class Entity

--- a/Highway/test/Highway.Data.Tests/InMemory/ShortIdentityStrategyTests.cs
+++ b/Highway/test/Highway.Data.Tests/InMemory/ShortIdentityStrategyTests.cs
@@ -1,7 +1,4 @@
-﻿
-using FluentAssertions;
-using Highway.Data.Contexts;
-using Highway.Data.Tests.InMemory.Domain;
+﻿using Highway.Data.Contexts;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 
@@ -10,13 +7,11 @@ namespace Highway.Data.Tests.InMemory
     [TestClass]
     public class ShortIdentityStrategyTests
     {
-        private readonly short seedNumber = 500;
         private ShortIdentityStrategy<Entity> target;
 
         [TestInitialize]
         public void Setup()
         {
-            ShortIdentityStrategy<Entity>.LastValue = seedNumber;
             target = new ShortIdentityStrategy<Entity>(x => x.Id);
         }
 
@@ -29,7 +24,7 @@ namespace Highway.Data.Tests.InMemory
             var result = target.Next();
 
             // Assert
-            Assert.AreEqual(seedNumber + 1, result);
+            Assert.AreEqual(1, result);
         }
 
         [TestMethod]
@@ -42,7 +37,7 @@ namespace Highway.Data.Tests.InMemory
             target.Assign(entity);
 
             // Assert
-            Assert.AreEqual(seedNumber + 1, entity.Id);
+            Assert.AreEqual(1, entity.Id);
         }
 
         class Entity

--- a/Highway/test/Highway.Data.Tests/OData/BasicODataQueryTests.cs
+++ b/Highway/test/Highway.Data.Tests/OData/BasicODataQueryTests.cs
@@ -4,7 +4,7 @@ using System.Web;
 using FluentAssertions;
 using Highway.Data.Contexts;
 using Highway.Data.OData;
-using Highway.Data.Tests.Security;
+using Highway.Data.Tests.Entities;
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 


### PR DESCRIPTION
Several changes:
- Updated Identity strategies to be non-static.
- Added tests to assert that incrementable (short, int, long) identity strategies reset to the default of 0 when an InMemoryDataContext instance is overwritten with a new one.
- Updates to LastValue are (still) thread-safe.
- Gave some IdentityStrategy<TType, TIdentity> properties protected setters.  Cleaned up affected tests.  Commented all API public surface area in the IIdentityStragy interface and its implementations.
- All but integration tests are passing, and I cannot run them successfully without a database instance.
