### PR TITLE
Display meaningful error messages.

### DIFF
--- a/Highway/src/Highway.Data.EntityFramework/Extensions/DbContextExtentions.cs
+++ b/Highway/src/Highway.Data.EntityFramework/Extensions/DbContextExtentions.cs
@@ -1,0 +1,21 @@
+﻿using System;
+using System.Data;
+
+namespace Highway.Data.EntityFramework
+{
+    public static class DbContextExtentions
+    {
+        public static void ValidateAndCommit(this IUnitOfWork context)
+        {
+            try
+            {
+                context.Commit();
+            }
+            catch (DataException x)
+            {
+                string fullMessage = x.FullMessage();
+                throw new InvalidOperationException(fullMessage, x);
+            }
+        }
+    }
+}

--- a/Highway/src/Highway.Data.EntityFramework/Extensions/ExceptionExtensions.cs
+++ b/Highway/src/Highway.Data.EntityFramework/Extensions/ExceptionExtensions.cs
@@ -1,0 +1,45 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Data.Entity.Validation;
+using System.Linq;
+
+namespace Highway.Data.EntityFramework
+{
+    public static class ExceptionExtensions
+    {
+        public static string FullMessage(this Exception exception)
+        {
+            return String.Join(" ", exception
+                .NestedExceptions()
+                .Select(x => x.MeaningfulMessage()));
+        }
+
+        public static string MeaningfulMessage(this Exception exception)
+        {
+            var result = exception.Message;
+
+            var validationException = exception as DbEntityValidationException;
+
+            if (validationException != null)
+            {
+                var errors =
+                    from entity in validationException.EntityValidationErrors
+                    from error in entity.ValidationErrors
+                    select $"{error.ErrorMessage} Property name: {entity.Entry.Entity.GetType().Name}.{error.PropertyName}.";
+
+                result = String.Join(", ", errors);
+            }
+
+            return result;
+        }
+
+        public static IEnumerable<Exception> NestedExceptions(this Exception exception)
+        {
+            while (exception != null)
+            {
+                yield return exception;
+                exception = exception.InnerException;
+            }
+        }
+    }
+}

--- a/Highway/src/Highway.Data.EntityFramework/Highway.Data.EntityFramework.csproj
+++ b/Highway/src/Highway.Data.EntityFramework/Highway.Data.EntityFramework.csproj
@@ -89,6 +89,8 @@
     <Compile Include="Contexts\DomainContext.cs" />
     <Compile Include="Database\DropCreateInitializer.cs" />
     <Compile Include="DefaultContextConfiguration.cs" />
+    <Compile Include="Extensions\DbContextExtentions.cs" />
+    <Compile Include="Extensions\ExceptionExtensions.cs" />
     <Compile Include="Interceptors\DynamicFilters\DynamicFilterCommandInterceptor.cs" />
     <Compile Include="Interceptors\DynamicFilters\DynamicFilterConstants.cs" />
     <Compile Include="Interceptors\DynamicFilters\DynamicFilterConvention.cs" />


### PR DESCRIPTION
Entity validation exceptions are unparsable. Use the ValidateAndCommit
extension method to turn them into useful, actionable messages.
