### PR TITLE
allow Commands to execute commands

### DIFF
--- a/src/Highway.Data/QueryObjects/Command.cs
+++ b/src/Highway.Data/QueryObjects/Command.cs
@@ -12,7 +12,7 @@ namespace Highway.Data
 		/// <summary>
 		///     The Command that will be executed at some point in the future
 		/// </summary>
-		protected Action<IReadOnlyUnitOfWork> ContextQuery { get; set; }
+		protected Action<IUnitOfWork> ContextQuery { get; set; }
 
 
 		/// <summary>


### PR DESCRIPTION
The `Command` class's `ContextQuery` property is an `Action<IReadOnlyUnitOfWork>` instead of an `Action<IUnitOfWork>`, which is preventing `Command`s from being able to modify the database.