### PR TITLE
Apply Appended Expressions to the Projector, rather than the Selector, in Selector/Projector queries.

### DIFF
--- a/src/Highway.Data.EntityFramework.Test/Given_A_Generic_Repository.cs
+++ b/src/Highway.Data.EntityFramework.Test/Given_A_Generic_Repository.cs
@@ -61,6 +61,27 @@ namespace Highway.Data.EntityFramework.Test
         }
 
         [TestMethod]
+        public void Should_Extend_Query_Objects()
+        {
+            //Arrange
+            context = new InMemoryDataContext();
+            context.Add(new Foo {Id = 1, Name = "Test"});
+            context.Add(new Foo {Id = 2, Name = "Test2"});
+            context.Commit();
+            target = new Repository(context);
+
+            //Act
+            var query = new FindFoo().Skip(1).Take(1);
+            IEnumerable<Foo> result = target.Find(query);
+
+            //Assert
+            Foo foo = result.First();
+            foo.Should().NotBeNull();
+            foo.Id.Should().Be(2);
+            foo.Name.Should().Be("Test2");
+        }
+
+        [TestMethod]
         public void Should_Execute_Scalar_Objects_That_Return_Values()
         {
             //Arrange

--- a/src/Highway.Data.EntityFramework.Test/Given_A_Generic_Repository.cs
+++ b/src/Highway.Data.EntityFramework.Test/Given_A_Generic_Repository.cs
@@ -67,11 +67,12 @@ namespace Highway.Data.EntityFramework.Test
             context = new InMemoryDataContext();
             context.Add(new Foo {Id = 1, Name = "Test"});
             context.Add(new Foo {Id = 2, Name = "Test2"});
+            context.Add(new Foo {Id = 3, Name = "NoMatch"});
             context.Commit();
             target = new Repository(context);
 
             //Act
-            var query = new FindFoo().Skip(1).Take(1);
+            var query = new FindFoo().Where(x => x.Name.Contains("Test")).Skip(1).Take(1);
             IEnumerable<Foo> result = target.Find(query);
 
             //Assert

--- a/src/Highway.Data.EntityFramework.Test/Given_A_Generic_Repository.cs
+++ b/src/Highway.Data.EntityFramework.Test/Given_A_Generic_Repository.cs
@@ -76,10 +76,54 @@ namespace Highway.Data.EntityFramework.Test
             IEnumerable<Foo> result = target.Find(query);
 
             //Assert
-            Foo foo = result.First();
+            Foo foo = result.Single();
             foo.Should().NotBeNull();
             foo.Id.Should().Be(2);
             foo.Name.Should().Be("Test2");
+        }
+
+        [TestMethod]
+        public void Should_Extend_Selector_Projector_Query_Objects()
+        {
+            //Arrange
+            context = new InMemoryDataContext();
+
+            // Create the first Foo, with two Bar children.  This is the non-matching Foo.
+            var nonMatchingFoo = new Foo
+            {
+                Id = 1, Name = "Foo1", Bars = new List<Bar>()
+                {
+                    new Bar {Id = 1, Name = "Bar1"},
+                    new Bar {Id = 2, Name = "Bar2"}
+                }
+            };
+
+            // Create the second Foo, with three bar children.  This is the Foo we'll match in our query.
+            // Only two of the bars will match the .Where extension on our query.
+            var matchingFoo = new Foo
+            {
+                Id = 2, Name = "Foo2", Bars = new List<Bar>()
+                {
+                    new Bar {Id = 3, Name = "MatchingBar3"},
+                    new Bar {Id = 4, Name = "MatchingBar4"},
+                    new Bar {Id = 5, Name = "Bar5"}
+                }
+            };
+
+            context.Add(nonMatchingFoo);
+            context.Add(matchingFoo);
+            context.Commit();
+            target = new Repository(context);
+
+            //Act
+            var query = new FindBarByFooId(2).Where(x => x.Name.Contains("Matching")).Skip(1).Take(1);
+            IEnumerable<Bar> result = target.Find(query);
+
+            //Assert
+            Bar bar = result.Single();
+            bar.Should().NotBeNull();
+            bar.Id.Should().Be(4);
+            bar.Name.Should().Be("MatchingBar4");
         }
 
         [TestMethod]

--- a/src/Highway.Data.EntityFramework.Test/TestDomain/Queries/FindBarByFooId.cs
+++ b/src/Highway.Data.EntityFramework.Test/TestDomain/Queries/FindBarByFooId.cs
@@ -1,0 +1,15 @@
+﻿using System.Linq;
+using Highway.Data.Tests.TestDomain;
+
+namespace Highway.Data.EntityFramework.Test.TestDomain.Queries
+{
+    public class FindBarByFooId : Query<Foo, Bar>
+    {
+        public FindBarByFooId(int fooId)
+        {
+            Selector = c => c.AsQueryable<Foo>().Where(foo => foo.Id == fooId);
+
+            Projector = foos => foos.SelectMany(foo => foo.Bars);
+        }
+    }
+}

--- a/src/Highway.Data/QueryObjects/Query`2.cs
+++ b/src/Highway.Data/QueryObjects/Query`2.cs
@@ -53,14 +53,16 @@ namespace Highway.Data
         /// <returns>The combined query</returns>
         protected IQueryable<TProjection> AppendExpressions(IQueryable<TSelection> query)
         {
-            var source = query;
+            var source = Projector(query);
+
             foreach (var exp in ExpressionList)
             {
                 List<Expression> newParams = exp.Item2.ToList();
                 newParams.Insert(0, source.Expression);
-                source = source.Provider.CreateQuery<TSelection>(Expression.Call(null, exp.Item1, newParams));
+                source = source.Provider.CreateQuery<TProjection>(Expression.Call(null, exp.Item1, newParams));
             }
-            return Projector(source);
+
+            return source;
         }
 
         protected IQueryable<TProjection> PrepareQuery(IDataContext context)


### PR DESCRIPTION
In Query<TSelection, TProjection>.AppendExpressions, any Expressions added to QueryBase.ExpressionList are appended to TSelection rather than TProjector.  This throws an ArgumentException similar to this:

System.ArgumentException: Expression of type 'System.Linq.IQueryable1[**TSelector**]' cannot be used for parameter of type 'System.Linq.IQueryable1[**TProjector**]' of method 'System.Linq.IQueryable1[**TProjector**]

I have altered the class to that Expressions are instead applied to TProjector.