### PR TITLE
make ReadonlyDataContext.AsQueryable virtual

### DIFF
--- a/src/Highway.Data.EntityFramework/Contexts/ReadonlyDataContext.cs
+++ b/src/Highway.Data.EntityFramework/Contexts/ReadonlyDataContext.cs
@@ -163,7 +163,7 @@ namespace Highway.Data
         /// <returns>
         ///     <see cref="IQueryable{T}" />
         /// </returns>
-        public IQueryable<T> AsQueryable<T>()
+        public virtual IQueryable<T> AsQueryable<T>()
             where T : class
         {
             return _context.InnerSet<T>();


### PR DESCRIPTION
This makes ReadonlyDataContext.AsQueryable virtual so it can be overridden in derived types.