### PR TITLE
Develop

### DIFF
--- a/src/Highway.Data.EntityFramework/Contexts/ReadonlyDataContext.cs
+++ b/src/Highway.Data.EntityFramework/Contexts/ReadonlyDataContext.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.Data.Common;
 using System.Data.Entity;
 using System.Linq;
@@ -11,10 +10,8 @@ using Highway.Data.EntityFramework;
 
 namespace Highway.Data
 {
-    public class ReadonlyDataContext : IReadonlyEntityDataContext
+    public class ReadonlyDataContext : ReadonlyDbContext, IReadonlyEntityDataContext
     {
-        private readonly ReadonlyDbContext _context;
-
         /// <summary>
         ///     Constructs a readonly context
         /// </summary>
@@ -65,8 +62,8 @@ namespace Highway.Data
             IMappingConfiguration mapping,
             IContextConfiguration contextConfiguration,
             ILog log)
+            : base(connectionString, mapping, contextConfiguration, log)
         {
-            _context = new ReadonlyDbContext(connectionString, mapping, contextConfiguration, log);
         }
 
         /// <summary>
@@ -90,8 +87,8 @@ namespace Highway.Data
         /// </param>
         /// <param name="log">The logger for the database first context</param>
         public ReadonlyDataContext(string databaseFirstConnectionString, ILog log)
+            : base(databaseFirstConnectionString, log)
         {
-            _context = new ReadonlyDbContext(databaseFirstConnectionString, log);
         }
 
         /// <summary>
@@ -151,8 +148,8 @@ namespace Highway.Data
             IMappingConfiguration mapping,
             IContextConfiguration contextConfiguration,
             ILog log)
+            : base(dbConnection, contextOwnsConnection, mapping, contextConfiguration, log)
         {
-            _context = new ReadonlyDbContext(dbConnection, contextOwnsConnection, mapping, contextConfiguration, log);
         }
 
         /// <summary>
@@ -166,25 +163,7 @@ namespace Highway.Data
         public virtual IQueryable<T> AsQueryable<T>()
             where T : class
         {
-            return _context.InnerSet<T>();
-        }
-
-        public void Dispose()
-        {
-            _context?.Dispose();
-        }
-
-        /// <summary>
-        ///     Executes a SQL command and tries to map the returned dataset into an <see cref="IEnumerable{T}" />
-        ///     The results should have the same column names as the Entity Type has properties
-        /// </summary>
-        /// <typeparam name="T">The Entity Type that the return should be mapped to</typeparam>
-        /// <param name="sql">The Sql Statement</param>
-        /// <param name="dbParams">A List of Database Parameters for the Query</param>
-        /// <returns>An <see cref="IEnumerable{T}" /> from the query return</returns>
-        public IEnumerable<T> ExecuteSqlQuery<T>(string sql, params DbParameter[] dbParams)
-        {
-            return _context.ExecuteSqlQuery<T>(sql, dbParams);
+            return InnerSet<T>();
         }
 
         /// <summary>
@@ -196,7 +175,7 @@ namespace Highway.Data
         public virtual T Reload<T>(T item)
             where T : class
         {
-            var entry = _context.Entry(item);
+            var entry = Entry(item);
             if (entry == null)
             {
                 throw new InvalidOperationException("You cannot reload an object that is not in the current Entity Framework data context");

--- a/src/Highway.Data.EntityFramework/Contexts/ReadonlyDataContext.cs
+++ b/src/Highway.Data.EntityFramework/Contexts/ReadonlyDataContext.cs
@@ -163,7 +163,7 @@ namespace Highway.Data
         /// <returns>
         ///     <see cref="IQueryable{T}" />
         /// </returns>
-        public IQueryable<T> AsQueryable<T>()
+        public virtual IQueryable<T> AsQueryable<T>()
             where T : class
         {
             return _context.InnerSet<T>();

--- a/src/Highway.Data.EntityFramework/Contexts/ReadonlyDbContext.cs
+++ b/src/Highway.Data.EntityFramework/Contexts/ReadonlyDbContext.cs
@@ -12,7 +12,7 @@ using Common.Logging;
 
 namespace Highway.Data
 {
-    internal class ReadonlyDbContext : DbContext
+    public class ReadonlyDbContext : DbContext
     {
         private readonly bool _databaseFirst;
 

--- a/src/Highway.Data.EntityFramework/Highway.Data.EntityFramework.csproj
+++ b/src/Highway.Data.EntityFramework/Highway.Data.EntityFramework.csproj
@@ -16,10 +16,11 @@
 	<PropertyGroup>
 		<TargetFrameworks>netstandard2.1;net45</TargetFrameworks>
 		<GeneratePackageOnBuild>true</GeneratePackageOnBuild>
+		<RootNamespace>Highway.Data</RootNamespace>
 	</PropertyGroup>
 
 	<ItemGroup>
-		<None Include="..\images\icon.png" Pack="true" PackagePath="\"/>
+		<None Include="..\images\icon.png" Pack="true" PackagePath="\" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/src/Highway.Data.EntityFramework/Highway.Data.EntityFramework.csproj.DotSettings
+++ b/src/Highway.Data.EntityFramework/Highway.Data.EntityFramework.csproj.DotSettings
@@ -1,0 +1,2 @@
+﻿<wpf:ResourceDictionary xml:space="preserve" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:s="clr-namespace:System;assembly=mscorlib" xmlns:ss="urn:shemas-jetbrains-com:settings-storage-xaml" xmlns:wpf="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
+	<s:Boolean x:Key="/Default/CodeInspection/NamespaceProvider/NamespaceFoldersToSkip/=repositories/@EntryIndexedValue">True</s:Boolean></wpf:ResourceDictionary>


### PR DESCRIPTION
This fixes a bug introduced (by me) in v8.0.0-Beta1, which caused ReadonlyDbContext.OnModelCreating to only fire once per domain.  This is because OnModelCreating only fires once per custom DbContext derivative.  By inheriting from DbContext, rather than having a private instance of it, each final ReadonlyDomainRepository<TDomain> will wind up invoking OnModelCreating.

There are ways around this, primarily by implementing IDbModelCacheKeyProvider, but this approach moves the ReadonlyDataContext back inline with what the original Highway.Data.DataContext does.  I prefer this approach for now, and recommended revisiting the inheritance / composition concern for EF Core.

https://stackoverflow.com/questions/33076291/onmodelcreating-is-never-called