### PR TITLE
Update .Net Framework and Package Versions

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -3,7 +3,7 @@
   "isRoot": true,
   "tools": {
     "cake.tool": {
-      "version": "2.0.0",
+      "version": "3.0.0",
       "commands": [
         "dotnet-cake"
       ]

--- a/src/Highway.Data.EntityFramework.Test/Highway.Data.EntityFramework.Test.csproj
+++ b/src/Highway.Data.EntityFramework.Test/Highway.Data.EntityFramework.Test.csproj
@@ -10,7 +10,7 @@
     <PackageReference Include="Devart.Data.SQLite.EF6" Version="5.14.1519" />
     <PackageReference Include="EntityFramework" Version="6.3.0" />
     <PackageReference Include="FluentAssertions" Version="5.9.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.3.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.5.0" />
     <PackageReference Include="Moq" Version="4.13.1" />
     <PackageReference Include="MSTest.TestAdapter" Version="2.0.0" />
     <PackageReference Include="MSTest.TestFramework" Version="2.0.0" />

--- a/src/Highway.Data.EntityFramework.Test/Highway.Data.EntityFramework.Test.csproj
+++ b/src/Highway.Data.EntityFramework.Test/Highway.Data.EntityFramework.Test.csproj
@@ -9,7 +9,7 @@
   <ItemGroup>
     <PackageReference Include="Devart.Data.SQLite.EF6" Version="5.14.1519" />
     <PackageReference Include="EntityFramework" Version="6.3.0" />
-    <PackageReference Include="FluentAssertions" Version="5.9.0" />
+    <PackageReference Include="FluentAssertions" Version="6.10.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.5.0" />
     <PackageReference Include="Moq" Version="4.13.1" />
     <PackageReference Include="MSTest.TestAdapter" Version="2.0.0" />

--- a/src/Highway.Data.EntityFramework.Test/Highway.Data.EntityFramework.Test.csproj
+++ b/src/Highway.Data.EntityFramework.Test/Highway.Data.EntityFramework.Test.csproj
@@ -12,8 +12,8 @@
     <PackageReference Include="FluentAssertions" Version="6.10.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.5.0" />
     <PackageReference Include="Moq" Version="4.13.1" />
-    <PackageReference Include="MSTest.TestAdapter" Version="2.0.0" />
-    <PackageReference Include="MSTest.TestFramework" Version="2.0.0" />
+    <PackageReference Include="MSTest.TestAdapter" Version="3.0.2" />
+    <PackageReference Include="MSTest.TestFramework" Version="3.0.2" />
     <PackageReference Include="coverlet.collector" Version="1.1.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/src/Highway.Data.EntityFramework/Highway.Data.EntityFramework.csproj
+++ b/src/Highway.Data.EntityFramework/Highway.Data.EntityFramework.csproj
@@ -14,7 +14,7 @@
 	</PropertyGroup>
 
 	<PropertyGroup>
-		<TargetFrameworks>netstandard2.1;net45</TargetFrameworks>
+		<TargetFrameworks>netstandard2.1;net462</TargetFrameworks>
 		<GeneratePackageOnBuild>true</GeneratePackageOnBuild>
 		<RootNamespace>Highway.Data</RootNamespace>
 	</PropertyGroup>

--- a/src/Highway.Data.ReadonlyTests/Highway.Data.ReadonlyTests.csproj
+++ b/src/Highway.Data.ReadonlyTests/Highway.Data.ReadonlyTests.csproj
@@ -15,8 +15,8 @@
 		<PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="6.0.0" />
 		<PackageReference Include="Microsoft.Extensions.Logging" Version="6.0.0" />
 		<PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="6.0.0" />
-		<PackageReference Include="MSTest.TestAdapter" Version="2.2.8" />
-		<PackageReference Include="MSTest.TestFramework" Version="2.2.8" />
+		<PackageReference Include="MSTest.TestAdapter" Version="3.0.2" />
+		<PackageReference Include="MSTest.TestFramework" Version="3.0.2" />
 		<PackageReference Include="System.Data.SqlClient" Version="4.8.5" />
 		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.5.0" />
 	</ItemGroup>

--- a/src/Highway.Data.ReadonlyTests/Highway.Data.ReadonlyTests.csproj
+++ b/src/Highway.Data.ReadonlyTests/Highway.Data.ReadonlyTests.csproj
@@ -18,7 +18,7 @@
 		<PackageReference Include="MSTest.TestAdapter" Version="2.2.8" />
 		<PackageReference Include="MSTest.TestFramework" Version="2.2.8" />
 		<PackageReference Include="System.Data.SqlClient" Version="4.8.3" />
-		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />
+		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.5.0" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/src/Highway.Data.ReadonlyTests/Highway.Data.ReadonlyTests.csproj
+++ b/src/Highway.Data.ReadonlyTests/Highway.Data.ReadonlyTests.csproj
@@ -17,7 +17,7 @@
 		<PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="6.0.0" />
 		<PackageReference Include="MSTest.TestAdapter" Version="2.2.8" />
 		<PackageReference Include="MSTest.TestFramework" Version="2.2.8" />
-		<PackageReference Include="System.Data.SqlClient" Version="4.8.3" />
+		<PackageReference Include="System.Data.SqlClient" Version="4.8.5" />
 		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.5.0" />
 	</ItemGroup>
 

--- a/src/Highway.Data.ReadonlyTests/Highway.Data.ReadonlyTests.csproj
+++ b/src/Highway.Data.ReadonlyTests/Highway.Data.ReadonlyTests.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="FluentAssertions" Version="6.3.0" />
+		<PackageReference Include="FluentAssertions" Version="6.10.0" />
 		<PackageReference Include="Microsoft.Extensions.Configuration" Version="6.0.0" />
 		<PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="6.0.0" />
 		<PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="6.0.0" />

--- a/src/Highway.Data.Test/Highway.Data.Test.csproj
+++ b/src/Highway.Data.Test/Highway.Data.Test.csproj
@@ -9,9 +9,12 @@
   <ItemGroup>
     <PackageReference Include="FluentAssertions" Version="6.10.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.5.0" />
-    <PackageReference Include="MSTest.TestAdapter" Version="2.0.0" />
-    <PackageReference Include="MSTest.TestFramework" Version="2.0.0" />
-    <PackageReference Include="coverlet.collector" Version="1.0.1" />
+    <PackageReference Include="MSTest.TestAdapter" Version="3.0.2" />
+    <PackageReference Include="MSTest.TestFramework" Version="3.0.2" />
+    <PackageReference Include="coverlet.collector" Version="1.1.0">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Highway.Data.Test/Highway.Data.Test.csproj
+++ b/src/Highway.Data.Test/Highway.Data.Test.csproj
@@ -8,7 +8,7 @@
 
   <ItemGroup>
     <PackageReference Include="FluentAssertions" Version="5.9.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.2.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.5.0" />
     <PackageReference Include="MSTest.TestAdapter" Version="2.0.0" />
     <PackageReference Include="MSTest.TestFramework" Version="2.0.0" />
     <PackageReference Include="coverlet.collector" Version="1.0.1" />

--- a/src/Highway.Data.Test/Highway.Data.Test.csproj
+++ b/src/Highway.Data.Test/Highway.Data.Test.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="FluentAssertions" Version="5.9.0" />
+    <PackageReference Include="FluentAssertions" Version="6.10.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.5.0" />
     <PackageReference Include="MSTest.TestAdapter" Version="2.0.0" />
     <PackageReference Include="MSTest.TestFramework" Version="2.0.0" />

--- a/src/Highway.Data/Highway.Data.csproj
+++ b/src/Highway.Data/Highway.Data.csproj
@@ -14,7 +14,7 @@
 	</PropertyGroup>
 
 	<PropertyGroup>
-		<TargetFrameworks>netstandard2.1;net45</TargetFrameworks>
+		<TargetFrameworks>netstandard2.1;net462</TargetFrameworks>
 		<GeneratePackageOnBuild>true</GeneratePackageOnBuild>
 	</PropertyGroup>
 


### PR DESCRIPTION
This pull request accomplishes three things:

1. .Net Framework 4.5 is out of support and is now difficult to even install on a development machine.  I have updated to 4.6.2, which is the oldest version still supported.  _These changes affect package assemblies_.
2. Several of the nuget packages in the solution have vulnerabilities through their transient dependencies.  These have been updated to the latest version.  _These changes only affect test projects_.
3. The "cake.tool" dotnet tool is updated to the latest version. 

All project unit and integration tests still pass, and the dotnet cake tasks still pass as well.