### PR TITLE
Forcibly set the connection string's ApplicationIntent property to "readonly" in the ReadonlyDbContext.

### DIFF
--- a/src/Highway.Data.EntityFramework/Contexts/ReadonlyDbContext.cs
+++ b/src/Highway.Data.EntityFramework/Contexts/ReadonlyDbContext.cs
@@ -10,6 +10,8 @@ using System.Threading.Tasks;
 
 using Common.Logging;
 
+using Highway.Data.Utilities;
+
 namespace Highway.Data
 {
     public class ReadonlyDbContext : DbContext
@@ -21,7 +23,7 @@ namespace Highway.Data
         private readonly IMappingConfiguration _mapping;
 
         public ReadonlyDbContext(string connectionString, IMappingConfiguration mapping, IContextConfiguration contextConfiguration, ILog log)
-            : base(connectionString)
+            : base(ReadonlySqlConnectionStringBuilder.GetConnectionString(connectionString))
         {
             _log = log;
             _mapping = mapping;
@@ -30,7 +32,7 @@ namespace Highway.Data
         }
 
         public ReadonlyDbContext(string databaseFirstConnectionString, ILog log)
-            : base(databaseFirstConnectionString)
+            : base(ReadonlySqlConnectionStringBuilder.GetConnectionString(databaseFirstConnectionString))
         {
             _databaseFirst = true;
             _log = log;

--- a/src/Highway.Data.EntityFramework/Utilities/ReadonlySqlConnectionStringBuilder.cs
+++ b/src/Highway.Data.EntityFramework/Utilities/ReadonlySqlConnectionStringBuilder.cs
@@ -1,0 +1,25 @@
+﻿// <copyright file="ReadonlySqlConnectionStringBuilder.cs" company="Enterprise Products Partners L.P. (Enterprise)">
+// © Copyright 2012 - 2019, Enterprise Products Partners L.P. (Enterprise), All Rights Reserved.
+// Permission to use, copy, modify, or distribute this software source code, binaries or
+// related documentation, is strictly prohibited, without written consent from Enterprise.
+// For inquiries about the software, contact Enterprise: Enterprise Products Company Law
+// Department, 1100 Louisiana, 10th Floor, Houston, Texas 77002, phone 713-381-6500.
+// </copyright>
+
+using System.Data.SqlClient;
+
+namespace Highway.Data.Utilities
+{
+    public static class ReadonlySqlConnectionStringBuilder
+    {
+        public static string GetConnectionString(string connectionString)
+        {
+            var connectionStringBuilder = new SqlConnectionStringBuilder(connectionString)
+            {
+                ApplicationIntent = ApplicationIntent.ReadOnly
+            };
+
+            return connectionStringBuilder.ConnectionString;
+        }
+    }
+}


### PR DESCRIPTION
This pull request takes the opinion that when using a ReadonlyDbContext the ApplicationIntent on the connection string should be set to "readonly."  This has the following effect:

1.  If the unaltered connection string would result in a connection to a SQL Server availability group configured for readonly routing, then the client connection is redirected to a readonly replica in the availability group.
2.  Otherwise the ApplicationIntent property of the connection string is ignored.

If the project maintainers are of the opinion that the ApplicationIntent should be determined by the consumer of the Highway.Data.EntityFramework package, then this pull request should be rejected.